### PR TITLE
feat: add HeroHttpDispatchers to demo w/o effects

### DIFF
--- a/src/app/heroes/heroes/heroes.component.ts
+++ b/src/app/heroes/heroes/heroes.component.ts
@@ -2,7 +2,11 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { MasterDetailCommands, Hero } from '../../core';
-import { HeroSelectors, HeroDispatchers } from '../../store';
+import {
+  HeroSelectors,
+  // HeroDispatchers,                     // <-- relies on effects
+  HeroHttpDispatchers as HeroDispatchers  // <-- bypass effects
+} from '../../store';
 
 @Component({
   selector: 'app-heroes',
@@ -21,8 +25,8 @@ export class HeroesComponent implements MasterDetailCommands<Hero>, OnInit {
     private heroDispatchers: HeroDispatchers,
     private heroSelectors: HeroSelectors
   ) {
-    this.heroes$ = this.heroSelectors.heroes$();
-    this.loading$ = this.heroSelectors.loading$();
+    this.heroes$ = this.heroSelectors.heroes$;
+    this.loading$ = this.heroSelectors.loading$;
   }
 
   ngOnInit() {

--- a/src/app/store/actions/hero.actions.ts
+++ b/src/app/store/actions/hero.actions.ts
@@ -24,6 +24,8 @@ export const DELETE_HERO = '[Hero] DELETE_HERO';
 export const DELETE_HERO_SUCCESS = '[Hero] DELETE_HERO_SUCCESS';
 export const DELETE_HERO_ERROR = '[Hero] DELETE_HERO_ERROR';
 
+export const SET_HERO_LOADING = '[Hero] SET_HERO_LOADING';
+
 export abstract class HeroAction implements DataAction<Hero> {
   readonly type: string;
   constructor(public readonly payload: Hero) {}
@@ -97,6 +99,11 @@ export class DeleteHeroError extends HeroErrorAction {
   readonly type = DELETE_HERO_ERROR;
 }
 
+export class SetHeroLoading {
+  readonly type = SET_HERO_LOADING;
+  constructor(public payload = true) {}
+}
+
 export type AllHeroActions =
   | GetHero
   | GetHeroSuccess
@@ -112,4 +119,5 @@ export type AllHeroActions =
   | AddHeroError
   | DeleteHero
   | DeleteHeroSuccess
-  | DeleteHeroError;
+  | DeleteHeroError
+  | SetHeroLoading;

--- a/src/app/store/effects/hero.effects.ts
+++ b/src/app/store/effects/hero.effects.ts
@@ -21,7 +21,7 @@ import { HeroDataService, DataServiceError } from '../services';
 import { HeroicState } from '../reducers';
 
 const filterAction = new HeroActions.GetHeroes();
-const toAction = HeroActions.toAction(); // TODO: do we need it?
+const toAction = HeroActions.toAction();
 type HeroAction = HeroActions.HeroAction;
 
 @Injectable()

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -4,7 +4,7 @@ export * from './reducers';
 export * from './services';
 
 import {
-  HeroDispatchers,
+  HeroDispatchers, HeroHttpDispatchers,
   HeroDataService,
   HeroSelectors,
   VillainDispatchers,
@@ -14,7 +14,7 @@ import {
 
 export const services = [
   HeroDataService,
-  HeroDispatchers,
+  HeroDispatchers, HeroHttpDispatchers,
   HeroSelectors,
   VillainDispatchers,
   VillainDataService,

--- a/src/app/store/reducers/hero.reducer.ts
+++ b/src/app/store/reducers/hero.reducer.ts
@@ -103,6 +103,13 @@ export function reducer(
         })
       };
     }
+
+    case HeroActions.SET_HERO_LOADING: {
+      return {
+        ...state,
+        loading: action.payload == null ? true : action.payload};
+    }
+
   }
   return state;
 }

--- a/src/app/store/services/hero-http-dispatchers.service.ts
+++ b/src/app/store/services/hero-http-dispatchers.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import {
+  concatMap,
+  catchError,
+  first,
+  map,
+  mergeMap
+} from 'rxjs/operators';
+
+import { Action, Store } from '@ngrx/store';
+
+import * as HeroActions from '../actions';
+
+import { DataServiceError } from './data.service';
+import { Hero } from '../../core';
+import { HeroDataService } from './hero-data.service';
+import { HeroicState } from '../reducers';
+
+const filterAction = new HeroActions.GetHeroes();
+type HeroAction = HeroActions.HeroAction;
+
+const loadingTrueAction = new HeroActions.SetHeroLoading(true);
+
+/**
+ * Make HTTP calls for Heroes
+ * dispatch the results (success or error) to ngrx store.
+ */
+@Injectable()
+export class HeroHttpDispatchers {
+  getHeroes() {
+    this.dispatchLoading();
+    this.heroDataService.getHeroes().subscribe(
+      heroes => this.dispatch(new HeroActions.GetHeroesSuccess(heroes)),
+      error => this.dispatch(new HeroActions.GetHeroesError(error))
+    );
+  }
+
+  addHero(hero: Hero) {
+    this.dispatchLoading();
+    this.heroDataService.addHero(hero).subscribe(
+      // pessimistic add: add hero to cache only when the server responds with success
+      addedHero => this.dispatch(new HeroActions.AddHeroSuccess(addedHero)),
+      error => this.dispatch(new HeroActions.AddHeroError(error))
+    );
+  }
+
+  deleteHero(hero: Hero) {
+    this.dispatchLoading();
+    // optimistic delete: delete hero immediately from cache, before making request
+    this.dispatch(new HeroActions.DeleteHero(hero));
+    this.heroDataService.deleteHero(hero).subscribe(
+      addedHero => this.dispatch(new HeroActions.DeleteHeroSuccess(addedHero)),
+      // no recovery: don't bother restoring the hero to cache when server responds with error
+      error => this.dispatch(new HeroActions.DeleteHeroError(error))
+    );
+  }
+
+  updateHero(hero: Hero) {
+    this.dispatchLoading();
+    this.heroDataService.updateHero(hero).subscribe(
+      // pessimistic update: update hero in cache only when the server responds with success
+      addedHero => this.dispatch(new HeroActions.UpdateHeroSuccess(addedHero)),
+      error => this.dispatch(new HeroActions.UpdateHeroError(error))
+    );
+  }
+
+  constructor(
+    private store: Store<HeroicState>,
+    private heroDataService: HeroDataService
+  ) {}
+
+  private dispatch = (action: Action) => this.store.dispatch(action);
+  private dispatchLoading = () => this.dispatch(loadingTrueAction);
+}

--- a/src/app/store/services/hero.selectors.ts
+++ b/src/app/store/services/hero.selectors.ts
@@ -8,14 +8,17 @@ import { HeroicState } from '../reducers';
 
 // selectors
 const getHeroicState = createFeatureSelector<HeroicState>('heroic');
+
 const getHeroState = createSelector(
   getHeroicState,
   (state: HeroicState) => state.heroes
 );
+
 const getAllHeroes = createSelector(
   getHeroicState,
   (state: HeroicState) => state.heroes.heroes
 );
+
 const getHeroesLoading = createSelector(
   getHeroicState,
   (state: HeroicState) => state.heroes.loading
@@ -24,20 +27,8 @@ const getHeroesLoading = createSelector(
 @Injectable()
 export class HeroSelectors {
   constructor(private store: Store<HeroicState>) {}
-
-  heroes$() {
-    return this.store.select(getAllHeroes);
-  }
-
-  heroState$() {
-    return this.store
-      .select(getHeroState)
-      .pipe(tap(heroState => console.log('heroState', heroState)));
-  }
-
-  loading$() {
-    return this.store
-      .select(getHeroesLoading)
-      .pipe(tap(loading => console.log('loading', loading)));
-  }
+  // selectors$
+  heroes$ = this.store.select(getAllHeroes);
+  heroState$ = this.store.select(getHeroState);
+  loading$ = this.store.select(getHeroesLoading);
 }

--- a/src/app/store/services/index.ts
+++ b/src/app/store/services/index.ts
@@ -1,7 +1,10 @@
 export { DataServiceError } from './data.service';
-export * from './villain-data.service';
 export * from './hero-data.service';
-export * from './villain.dispatchers';
+export * from './villain-data.service';
+
 export * from './hero.dispatchers';
-export * from './villain.selectors';
+export * from './hero-http-dispatchers.service';
+export * from './villain.dispatchers';
+
 export * from './hero.selectors';
+export * from './villain.selectors';

--- a/src/app/store/services/villain.selectors.ts
+++ b/src/app/store/services/villain.selectors.ts
@@ -8,14 +8,17 @@ import { HeroicState } from '../reducers';
 
 // selectors
 const getHeroicState = createFeatureSelector<HeroicState>('heroic');
-const getvillainState = createSelector(
+
+const getVillainState = createSelector(
   getHeroicState,
   (state: HeroicState) => state.villains
 );
+
 const getAllVillains = createSelector(
   getHeroicState,
   (state: HeroicState) => state.villains.villains
 );
+
 const getVillainsLoading = createSelector(
   getHeroicState,
   (state: HeroicState) => state.villains.loading
@@ -24,20 +27,8 @@ const getVillainsLoading = createSelector(
 @Injectable()
 export class VillainSelectors {
   constructor(private store: Store<HeroicState>) {}
-
-  villains$() {
-    return this.store.select(getAllVillains);
-  }
-
-  villainState$() {
-    return this.store
-      .select(getvillainState)
-      .pipe(tap(villainState => console.log('villainState', villainState)));
-  }
-
-  loading$() {
-    return this.store
-      .select(getVillainsLoading)
-      .pipe(tap(loading => console.log('loading', loading)));
-  }
+  // selectors$
+  villains$ = this.store.select(getAllVillains);
+  villainState$ = this.store.select(getVillainState);
+  loading$ = this.store.select(getVillainsLoading);
 }

--- a/src/app/villains/villains/villains.component.ts
+++ b/src/app/villains/villains/villains.component.ts
@@ -22,8 +22,8 @@ export class VillainsComponent
     private villainDispatchers: VillainDispatchers,
     private villainSelectors: VillainSelectors
   ) {
-    this.villains$ = this.villainSelectors.villains$();
-    this.loading$ = this.villainSelectors.loading$();
+    this.villains$ = this.villainSelectors.villains$;
+    this.loading$ = this.villainSelectors.loading$;
   }
 
   ngOnInit() {


### PR DESCRIPTION
**Demonstrates, for Heroes only, ngrx without using effects.**

Many people hate effects and don’t use them. I thought we should demonstrate how to live without them in our `ngrx-demo`.

>We should also show how to by-pass effects in the documentation for `ngrx-data` but that's a different story for a different repo.

Look here at the new `hero-http-dispatchers.service.ts` which bypasses effects.

The `HeroesComponent` can import either `HeroDispatchers` or `HeroHttpDispatchers` and inject either one.  In that branch I have it set to use `HeroHttpDispatchers`.

There is a new `SetHeroLoading` action for reasons that are obvious in `HeroHttpDispatchers`.

>Villains is untouched.

IMO (and many others) this is a perfectly reasonable way to roll. You do miss the initiating actions - in the redux tools, you see that the initiating actions are (`GetHeroes`, `AddHero`, `DeleteHero`, and `UpdateHero`) are never dispatched. But that seems a small price to pay if you can drop a concept and get close control over your http calls.  

>in fact, this approach is the secret to ONE of the `ngrx-data` extension points!

Our `ngrx-data` library _should continue to use effects_ because they make it easy for us to have a unified approach across all entity types. Off the top of my head, I’m not sure how we’d do without effects. (edited)
I’m not in love with the name `HeroHttpDispatchers`.  Suggestions welcome.

Do you think we should merge this? Leave in a separate branch? Make the point in some other way?

### Update 3/26

John reviewed and we agree to merge